### PR TITLE
[FIX]Allow to compare dates for Boarding pass in the past

### DIFF
--- a/src/main/java/com/ncredinburgh/iata/UTCCalendarFactory.java
+++ b/src/main/java/com/ncredinburgh/iata/UTCCalendarFactory.java
@@ -25,30 +25,36 @@ import java.util.TimeZone;
 public final class UTCCalendarFactory
 {
     public static final TimeZone UTC = TimeZone.getTimeZone("UTC");
+    
 
     private UTCCalendarFactory()
     {
     }
 
-    public static Calendar getInstanceForDayOfYear(int dayOfYear)
+    public static Calendar getInstanceForDayOfYear(int dayOfYear, Boolean forward)
     {
-        return getInstanceForDayOfYear(dayOfYear, Calendar.getInstance(UTC));
+    	forward = (forward != null) ? forward : true;
+        return getInstanceForDayOfYear(dayOfYear, Calendar.getInstance(UTC), forward);
     }
 
     /**
      * Creates {@link Calendar} instance in UTC from the given <code>dayOfYear</code>
      *
      * @param dayOfYear the day of year
+     * @param forward : indicates if the evaluation has to be done for a future or a past flight
+     * 					Default value is true to respect the previous code	
      * @param now the calendar representing the current date/time in UTC.
      * @return the new {@link Calendar} instance in UTC
      */
-    static Calendar getInstanceForDayOfYear(int dayOfYear, Calendar utc)
+    static Calendar getInstanceForDayOfYear(int dayOfYear, Calendar utc, Boolean forward)
     {
-        // getting current date in UTC
+    	forward = (forward != null) ? forward : true;
+    	
+    	// getting current date in UTC
         int utcDayOfYear = utc.get(Calendar.DAY_OF_YEAR);
         Calendar c = (Calendar) utc.clone();
-
-        if (dayOfYear < utcDayOfYear)
+        
+        if (dayOfYear < utcDayOfYear && forward)
         {
             // given dayOfYear must be in the following year
             c.roll(Calendar.YEAR, 1);

--- a/src/main/java/com/ncredinburgh/iata/UTCCalendarFactory.java
+++ b/src/main/java/com/ncredinburgh/iata/UTCCalendarFactory.java
@@ -26,30 +26,43 @@ public final class UTCCalendarFactory
 {
     public static final TimeZone UTC = TimeZone.getTimeZone("UTC");
     
+    /**
+     *  @param forward : indicates if the evaluation has to be done for a future or a past flight
+     * 					Default value is true to respect the previous code	
+     */
+    public static Boolean forward = true;
 
     private UTCCalendarFactory()
     {
     }
 
-    public static Calendar getInstanceForDayOfYear(int dayOfYear, Boolean forward)
+    public static Calendar getInstanceForDayOfYear(int dayOfYear)
     {
-    	forward = (forward != null) ? forward : true;
-        return getInstanceForDayOfYear(dayOfYear, Calendar.getInstance(UTC), forward);
+        return getInstanceForDayOfYear(dayOfYear, Calendar.getInstance(UTC));
     }
+    
+	public static Calendar getInstanceForDayOfYearBackward(int dayOfYear) {
+		setForward(false);
+		return getInstanceForDayOfYear(dayOfYear);
+	}
 
-    /**
+    public static Boolean getForward() {
+		return forward;
+	}
+
+	public static void setForward(Boolean forward) {
+		UTCCalendarFactory.forward = forward;
+	}
+
+	/**
      * Creates {@link Calendar} instance in UTC from the given <code>dayOfYear</code>
      *
      * @param dayOfYear the day of year
-     * @param forward : indicates if the evaluation has to be done for a future or a past flight
-     * 					Default value is true to respect the previous code	
      * @param now the calendar representing the current date/time in UTC.
      * @return the new {@link Calendar} instance in UTC
      */
-    static Calendar getInstanceForDayOfYear(int dayOfYear, Calendar utc, Boolean forward)
+    static Calendar getInstanceForDayOfYear(int dayOfYear, Calendar utc)
     {
-    	forward = (forward != null) ? forward : true;
-    	
     	// getting current date in UTC
         int utcDayOfYear = utc.get(Calendar.DAY_OF_YEAR);
         Calendar c = (Calendar) utc.clone();
@@ -78,4 +91,6 @@ public final class UTCCalendarFactory
         c.set(Calendar.HOUR_OF_DAY, 0);
         return c;
     }
+
+
 }

--- a/src/main/java/com/ncredinburgh/iata/model/FlightSegment.java
+++ b/src/main/java/com/ncredinburgh/iata/model/FlightSegment.java
@@ -86,6 +86,11 @@ public final class FlightSegment
         return dateOfFlight;
     }
 
+    public Calendar getDateOfFlightBackward()
+    {
+    	 Integer dateOfFlight = getJulianDateOfFlight();
+         return dateOfFlight != null ? UTCCalendarFactory.getInstanceForDayOfYearBackward(dateOfFlight) : null;
+    }    
     public Calendar getDateOfFlight()
     {
         Integer dateOfFlight = getJulianDateOfFlight();


### PR DESCRIPTION
When you try to check the dates of a flight thanks to an old value, this part of the code https://github.com/ncredinburgh/iata-parser/blob/master/src/main/java/com/ncredinburgh/iata/UTCCalendarFactory.java#L51 wasn't returning proper date but is putting it in the next year.

This part of code introduce a forward parameter set to true by default and help the user to choose which behavior you want 